### PR TITLE
Change version to match the latest version of FRP

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "js-frp",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "js-frp",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "decompress": "^4.2.1",

--- a/src/FRPUtil/constants.ts
+++ b/src/FRPUtil/constants.ts
@@ -1,3 +1,3 @@
 export default {
-    version: '0.44.0'
+    version: '0.61.0'
 }


### PR DESCRIPTION
Hey! I've noticed that some versions of the FRP have been released since the latest update into the repo used version. I've updated and tested with the version 0.61 and seems to work fine