### PR TITLE
Allow custom download directory

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,6 @@
 src
 lib 
 test.js
+tests
 examples
 tsconfig.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "js-frp",
-  "version": "0.1.1",
+  "version": "0.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "js-frp",
-      "version": "0.1.1",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "decompress": "^4.2.1",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "js-frp",
-  "version": "0.2.1",
+  "version": "0.3.1",
   "description": "A library written in TypeScript for managing FRP instances. FRP is a fast reverse proxy to help you expose a local server behind a NAT or firewall to the Internet.",
   "main": "dist",
   "types": "./dist/index.d.ts",
   "scripts": {
-    "build": "tsc"
+    "build": "tsc",
+    "test": "npm run build && node tests/index.js"
   },
   "author": "PondWader",
   "license": "MIT",

--- a/src/Class/Base.ts
+++ b/src/Class/Base.ts
@@ -37,18 +37,18 @@ export default class FRPBase extends EventEmitter {
     public process: ChildProcessWithoutNullStreams | null;
     public stdout: Readable | null;
 
-    constructor(executableName: string) {
+    constructor(executableName: string, binariesDir?: string) {
         super();
 
         this.executableName = executableName;
-        this.downloadPromise = this._download();
+        this.downloadPromise = this._download(binariesDir);
         this.id = Math.floor(Math.random() * 1000000);
         this.process = null;
         this.stdout = null;
     }
 
-    private async _download() {
-        this.binaryDir = await download();
+    private async _download(directory?: string) {
+        this.binaryDir = await download(directory);
     }
 
     async _writeConfig(conf: string) {

--- a/src/Class/Client.ts
+++ b/src/Class/Client.ts
@@ -6,9 +6,10 @@ class FRPClient extends FRPBase {
     /**
      * Create a new FRP client instance
      * @param {ClientConf} config The config for the instance
+     * @param {string} binariesDir The directory to download the binaries to (optional)
      */
-    constructor(config?: ClientConf) {
-        super('frpc');
+    constructor(config?: ClientConf, binariesDir?: string) {
+        super('frpc', binariesDir);
 
         if (config) this._writeConfig(ini.stringify(config));
     }

--- a/src/Class/Server.ts
+++ b/src/Class/Server.ts
@@ -6,10 +6,11 @@ class FRPServer extends FRPBase {
     /**
      * Create a new FRP server instance
      * @param {ServerConf} config The config for the instance
+     * @param {string} binariesDir The directory to download the binaries to (optional)
      */
-    constructor(config?: ServerConf) {
-        super('frps');
-        
+    constructor(config?: ServerConf, binariesDir?: string) {
+        super('frps', binariesDir);
+
         if (config) this._writeConfig(ini.stringify(config));
     }
 

--- a/src/FRPUtil/download.ts
+++ b/src/FRPUtil/download.ts
@@ -4,46 +4,49 @@ import constants from './constants';
 import { DownloaderHelper } from 'node-downloader-helper';
 import decompress from 'decompress';
 
-let downloading = false;
-let resolveAwaiters: ((value: string) => void)[] = [];
+let downloading: Set<string> = new Set();
+let resolveAwaiters: { [path: string]: ((value: string) => void)[] } = {};
 
-export default async function downloadFRP() : Promise<string> {
-    // If file is already downloading add the promise to an array of promises to be resolved once it's downloaded
-    if (downloading) {
-        return new Promise((resolve) => resolveAwaiters.push(resolve));
-    }
-    downloading = true;
-
+export default async function downloadFRP(directory?: string) : Promise<string> {
     const platform = process.platform;
     const arch = process.arch;
-
+    
     let release = `frp_${constants.version}`;
     let releaseFile = '';
-
+    
     switch(platform) {
         case "win32":
             release += `_windows_${arch === 'x64' ? 'amd64' : '386'}`;
             releaseFile = release + '.zip';
             break;
-        case "freebsd":
-            release += `_freebsd_${arch === 'x64' ? 'amd64' : '386'}`;
-            releaseFile = release + '.tar.gz';
-            break;
-        case "darwin":
-            release += `_darwin_${arch === 'arm64' ? 'arm64' : 'amd64'}`;
-            releaseFile = release + '.tar.gz';
-            break;
-        case "linux":
-            release += `_linux_${arch.replace('x64', 'amd64')}`;
-            releaseFile = release + '.tar.gz';
-            break;
+            case "freebsd":
+                release += `_freebsd_${arch === 'x64' ? 'amd64' : '386'}`;
+                releaseFile = release + '.tar.gz';
+                break;
+                case "darwin":
+                    release += `_darwin_${arch === 'arm64' ? 'arm64' : 'amd64'}`;
+                    releaseFile = release + '.tar.gz';
+                    break;
+                    case "linux":
+                        release += `_linux_${arch.replace('x64', 'amd64')}`;
+                        releaseFile = release + '.tar.gz';
+                        break;
     }
-
+    
     if (release === `frp_${constants.version}`) throw new Error(`A release was not found for your operating system (Platform: ${platform} Arch: ${arch})`);
-
-    const binariesDir = path.join(__dirname, '../../lib');
+    
+    const binariesDir = path.resolve(directory || path.join(__dirname, '../../lib'));
     const binaryPath = path.join(binariesDir, release);
 
+    // If file is already downloading add the promise to an array of promises to be resolved once it's downloaded
+    if (downloading.has(binaryPath)) {
+        return new Promise((resolve) => {
+            if (!resolveAwaiters[binaryPath]) resolveAwaiters[binaryPath] = [];
+            resolveAwaiters[binaryPath].push(resolve);
+        });
+    }
+    downloading.add(binaryPath);
+    
     // Check if file exists or not
     const stat = await fs.stat(binaryPath).catch(() => {});
     if (stat) {
@@ -89,9 +92,11 @@ async function cleanFiles(dir: string) {
 }
 
 function resolvePromises(value: string) {
-    downloading = false;
-    for (const resolve of resolveAwaiters) {
-        resolve(value);
+    downloading.delete(value);
+    if (resolveAwaiters[value]) {
+        for (const resolve of resolveAwaiters[value]) {
+            resolve(value);
+        }
+        delete resolveAwaiters[value];
     }
-    resolveAwaiters = [];
 }

--- a/tests/custom_binaries_dir.js
+++ b/tests/custom_binaries_dir.js
@@ -1,0 +1,31 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const { FRPClient } = require("../dist");
+
+async function run() {
+    const customPath = path.resolve("./binaries");
+    const client = new FRPClient({}, customPath);
+    await client.start();
+    await new Promise((resolve, reject) => {
+        client.on("message", (message) => {
+            if (message.includes(`start frpc service for config file [${client.getConfigPath()}]`)) resolve();
+            else reject(new Error("frpc did not start as expected.\nOutput: " + message));
+        });
+        setTimeout(() => {
+            reject(new Error("frpc did not start within 5 seconds."));
+        }, 5000);
+    });
+    client.stop();
+    try {
+        if (!fs.existsSync(client.getConfigPath()) || customPath !== path.resolve(client.getConfigPath()).split(path.sep).slice(0, -2).join(path.sep))
+            throw new Error("frpc config file does not exist in the custom binaries directory.");
+    } finally {
+        await fs.promises.rm(customPath, { recursive: true, force: true });
+    }
+}
+
+module.exports = {
+    name: "Custom Binaries Directory Test",
+    run,
+}

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,0 +1,39 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const testFiles = fs.globSync(path.join(__dirname, "*.js")).filter(file => file !== __filename);
+const tests = testFiles.map(file => require(file));
+
+ANSI_RESET = "\x1b[0m";
+ANSI_RED = "\x1b[0;31m";
+ANSI_GREEN = "\x1b[0;32m";
+ANSI_BLUE = "\x1b[0;34m";
+
+async function runTests() {
+    console.info(`Running ${tests.length} tests...`);
+    let index = 0;
+    let failed = 0;
+    for (const test of tests) {
+        index++;
+        let error;
+        try {
+            await test.run();
+        } catch (error) {
+            failed++;
+            error = error || new Error("Unknown error");
+        }
+        finally {
+            const statusString = error ? `${ANSI_RED}failed!${ANSI_RESET}` : `${ANSI_GREEN}passed${ANSI_RESET}`;
+            console.info(`${ANSI_BLUE}${index}. ${test.name}: ${statusString}${ANSI_RESET}`);
+            if (error) console.error(error);
+        }
+    }
+    if (failed > 0) {
+        console.error(`${ANSI_RED}${failed}/${tests.length} tests failed!${ANSI_RESET}`);
+    } else {
+        console.info(`${ANSI_GREEN}All tests passed.${ANSI_RESET}`);
+    }
+    process.exit(0);
+}
+
+runTests();


### PR DESCRIPTION
For a project I am using js-frp and electron with electron-forge to package my app. Since js-frp downloads to a fixed directory, when the app is packaged, there will be an error because the path would be inside the read-only asar file of the electron package. So js-frp could neither download the binaries, nor create the config file. That's why I added this change to be able to set the directory outside of that read-only file.

The changes are fully backwards compatible.

I also added a simple test for this as well, if you want that, otherwise I will remove it again.